### PR TITLE
Support direct links when enabled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,8 @@
     },
     "authors": [
         {
-            "name": "Charlie K",
-            "email": "charlie.k@redevs.org",
-            "role": "Developer"
-        },
-        {
-            "name": "David Sevilla Martín",
-            "email": "david.s@redevs.org",
+            "name": "Team Fof",
+            "email": "team@friendsofflarum.org",
             "role": "Developer"
         }
     ],
@@ -53,6 +48,9 @@
         },
         "flagrow": {
             "discuss": "https://discuss.flarum.org/d/17845"
-        }
+        },
+        "optional-dependencies": [
+            "zerosonesfun/direct-links"
+        ]
     }
 }


### PR DESCRIPTION
When sending email invites, this extension uses the route to forum base.

This PR adds option support for https://github.com/zerosonesfun/direct-links, and when this extension is enabled, invite emails use the route direct to the `/signup` modal, making it easier for new users to signup without having to navigate anywhere