### PR TITLE
Update to fix support when FoF Direct Links is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doorman by FriendsOfFlarum
 
-[![GitLab license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/FriendsOfFlarum/doorman/blob/master/LICENSE.md) [![Latest Stable Version](https://img.shields.io/packagist/v/fof/doorman.svg)](https://github.com/FriendsOfFlarum/doorman) [![OpenCollective](https://img.shields.io/badge/opencollective-fof-blue.svg)](https://opencollective.com/fof/donate) 
+[![GitLab license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/FriendsOfFlarum/doorman/blob/master/LICENSE.md) [![Latest Stable Version](https://img.shields.io/packagist/v/fof/doorman.svg)](https://github.com/FriendsOfFlarum/doorman) [![OpenCollective](https://img.shields.io/badge/opencollective-fof-blue.svg)](https://opencollective.com/fof/donate)
 
 A [Flarum](http://flarum.org) extension that restricts sign-ups to user's who have a code created in the admin panel.
 
@@ -27,7 +27,7 @@ Then login and enable the extension.
 
 ### Issues
 
-- [Open an issue on Github](https://github.com/FriendsOfFlarum/doorman/issues) 
+- [Open an issue on Github](https://github.com/FriendsOfFlarum/doorman/issues)
 
 ### Links
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Each code can be set to have a maximum number of uses, what group the user shoul
 ### Usage
 
 - Setup sign-up codes on the admin panel
-- Includes optional support for [Direct Links](https://github.com/zerosonesfun/direct-links). When this extension is also enabled, email invites will include a link which will take the uew user directly to the signup modal, rather than the forum home page.
+- Includes optional support for [Direct Links](https://github.com/FriendsOfFlarum/direct-links). When this extension is also enabled, email invites will include a link which will take the uew user directly to the signup modal, rather than the forum home page.
 
 ### Installation
 

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
             "discuss": "https://discuss.flarum.org/d/17845"
         },
         "optional-dependencies": [
-            "zerosonesfun/direct-links"
+            "fof/direct-links"
         ],
         "flarum-cli": {
             "modules": {

--- a/src/Api/Controllers/SendInvitesController.php
+++ b/src/Api/Controllers/SendInvitesController.php
@@ -96,7 +96,7 @@ class SendInvitesController extends AbstractCreateController
 
         $body = $this->translator->trans('fof-doorman.forum.email.body', [
             '{forum}' => $title,
-            '{url}'   => $this->extensions->isEnabled('zerosonesfun-direct-links') ? $this->url->to('forum')->route('direct-links-signup') : $this->url->to('forum')->base(),
+            '{url}'   => $this->extensions->isEnabled('fof-direct-links') ? $this->url->to('forum')->route('direct-links-signup') : $this->url->to('forum')->base(),
             '{code}'  => $doorkey->key,
         ]);
 


### PR DESCRIPTION
Update to src/Api/Controllers/SendInvitesController.php to fix a problem with support of direct links when FoF Direct Links extension is enabled.
original extension name was: zerosonesfun/direct-links
should reflect new extension name: fof/direct-links

**Fixes #46** which was broken when zerosonesfun/direct-links became fof/direct-links

**Changes proposed in this pull request:**
src/Api/Controllers/SendInvitesController.php
updated:
zerosonesfun-direct-links
to:
fof-direct-links

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
