### PR TITLE
fix: show max uses count when set to `0`

### DIFF
--- a/js/src/admin/components/DoorkeyListPage.tsx
+++ b/js/src/admin/components/DoorkeyListPage.tsx
@@ -160,7 +160,7 @@ export default class DoorkeyListPage extends ExtensionPage {
                   aria-rowindex={rowIndex + 2}
                   role="cell"
                 >
-                  {columnContent || app.translator.trans('fof-doorman.admin.list.content.invalid_column')}
+                  {columnContent ?? app.translator.trans('fof-doorman.admin.list.content.invalid_column')}
                 </div>
               );
             })

--- a/js/src/admin/components/DoorkeyListPage.tsx
+++ b/js/src/admin/components/DoorkeyListPage.tsx
@@ -160,7 +160,7 @@ export default class DoorkeyListPage extends ExtensionPage {
                   aria-rowindex={rowIndex + 2}
                   role="cell"
                 >
-                  {columnContent || app.translator.trans('fof-doorman.admin.page.doorkey.heading.invalid_column_content')}
+                  {columnContent || app.translator.trans('fof-doorman.admin.list.content.invalid_column')}
                 </div>
               );
             })

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -76,7 +76,7 @@ fof-doorman:
         uses: Uses
         created_by: Created By
       content:
-        invalid_column: => core.admin.users.grid.columns.invalid_column
+        invalid_column: => core.admin.users.grid.invalid_column_content
         no_group: => core.admin.users.grid.columns.group_badges.no_badges
         warning: This invite code has been used its max number of times.
         delete: Are you sure you want to delete the invite code "{key}"?

--- a/src/Repository/DoorkeyRepository.php
+++ b/src/Repository/DoorkeyRepository.php
@@ -24,14 +24,14 @@ class DoorkeyRepository
         return Doorkey::query();
     }
 
-    public function findOrFail($id, User $actor = null)
+    public function findOrFail($id, ?User $actor = null)
     {
         $query = $this->query()->where('id', $id);
 
         return $this->scopeVisibleTo($query, $actor)->firstOrFail();
     }
 
-    protected function scopeVisibleTo(Builder $query, User $actor = null)
+    protected function scopeVisibleTo(Builder $query, ?User $actor = null)
     {
         if ($actor !== null) {
             $query->whereVisibleTo($actor);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
* Use correct translation keys
* Ensure `0` max uses can be displayed properly

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
